### PR TITLE
Add Link binary animation export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*/__pycache__/
+io_export_objex2/io_export_objex2_updater/
+.directory

--- a/io_export_objex2/__init__.py
+++ b/io_export_objex2/__init__.py
@@ -195,6 +195,11 @@ class OBJEX_OT_export_base():
             description='Write out the ANIM file',
             default=export_objex.ObjexWriter.default_options['EXPORT_ANIM'],
             )
+    link_anim_bin = BoolProperty(
+            name='Write Link anim BINs',
+            description='Write binary animation data for Link',
+            default=export_objex.ObjexWriter.default_options['EXPORT_LINK_ANIM_BIN'],
+            )
     use_weights = BoolProperty(
             name='Write Weights',
             description='Write out the vertex weights',
@@ -312,6 +317,9 @@ class OBJEX_OT_export_base():
             box = self.layout.box()
             box.prop(self, 'use_skeletons')
             box.prop(self, 'use_animations')
+            if self.use_animations:
+                box2 = box.box()
+                box2.prop(self, 'link_anim_bin')
             if self.use_weights:
                 box2 = box.box()
                 box2.prop(self, 'use_weights')

--- a/io_export_objex2/__init__.py
+++ b/io_export_objex2/__init__.py
@@ -200,6 +200,12 @@ class OBJEX_OT_export_base():
             description='Write binary animation data for Link',
             default=export_objex.ObjexWriter.default_options['EXPORT_LINK_ANIM_BIN'],
             )
+    link_bin_scale = FloatProperty(
+            name='Link bin scale',
+            description='If your Link is about 4 (young) / 6 (adult) units tall, this should be 1000',
+            soft_min=1.0, soft_max=1000.0,
+            default=export_objex.ObjexWriter.default_options['LINK_BIN_SCALE'],
+            )
     use_weights = BoolProperty(
             name='Write Weights',
             description='Write out the vertex weights',
@@ -320,6 +326,7 @@ class OBJEX_OT_export_base():
             if self.use_animations:
                 box2 = box.box()
                 box2.prop(self, 'link_anim_bin')
+                box2.prop(self, 'link_bin_scale')
             if self.use_weights:
                 box2 = box.box()
                 box2.prop(self, 'use_weights')

--- a/io_export_objex2/export_objex.py
+++ b/io_export_objex2/export_objex.py
@@ -62,6 +62,7 @@ class ObjexWriter():
         'EXPORT_SKEL': True,
         'EXPORT_ANIM': True,
         'EXPORT_LINK_ANIM_BIN': False,
+        'LINK_BIN_SCALE': 1000.0,
         'EXPORT_WEIGHTS': True,
         'UNIQUE_WEIGHTS': False,
         'APPLY_MODIFIERS': True,
@@ -710,7 +711,9 @@ class ObjexWriter():
                                 link_anim_basepath = self.filepath_linkbase
                         else:
                             animfile_write = None
-                        export_objex_anim.write_armatures(skelfile_write, animfile_write, scene, self.options['GLOBAL_MATRIX'], self.armatures, link_anim_basepath)
+                        export_objex_anim.write_armatures(skelfile_write, animfile_write, 
+                            scene, self.options['GLOBAL_MATRIX'], self.armatures, 
+                            link_anim_basepath, self.options['LINK_BIN_SCALE'])
                     finally:
                         if skelfile:
                             skelfile.close()
@@ -736,6 +739,7 @@ def save(context,
          use_skeletons=None,
          use_animations=None,
          link_anim_bin=None,
+         link_bin_scale=None,
          use_weights=None,
          use_unique_weights=None,
          use_mesh_modifiers=None,

--- a/io_export_objex2/export_objex.py
+++ b/io_export_objex2/export_objex.py
@@ -61,6 +61,7 @@ class ObjexWriter():
         'EXPORT_MTL': True,
         'EXPORT_SKEL': True,
         'EXPORT_ANIM': True,
+        'EXPORT_LINK_ANIM_BIN': False,
         'EXPORT_WEIGHTS': True,
         'UNIQUE_WEIGHTS': False,
         'APPLY_MODIFIERS': True,
@@ -116,6 +117,8 @@ class ObjexWriter():
             if self.options['EXPORT_ANIM']:
                 self.filepath_anim = os.path.splitext(self.filepath)[0] + ".anim"
                 fw('animlib %s\n' % repr(os.path.basename(self.filepath_anim))[1:-1])
+                if self.options['EXPORT_LINK_ANIM_BIN']:
+                    self.filepath_linkbase = os.path.splitext(self.filepath)[0] + '_'
     
     def write_uvs(self, mesh, face_index_pairs):
         fw = self.fw_objex
@@ -696,14 +699,18 @@ class ObjexWriter():
                         skelfile = open(self.filepath_skel, "w", encoding="utf8", newline="\n")
                         skelfile_write = skelfile.write
                         skelfile_write(self.export_id_line)
+                        link_anim_basepath = None
                         if self.options['EXPORT_ANIM']:
                             log.info(' ... and animations')
                             animfile = open(self.filepath_anim, "w", encoding="utf8", newline="\n")
                             animfile_write = animfile.write
                             animfile_write(self.export_id_line)
+                            if self.options['EXPORT_LINK_ANIM_BIN']:
+                                log.info(' ... and Link animation binaries')
+                                link_anim_basepath = self.filepath_linkbase
                         else:
                             animfile_write = None
-                        export_objex_anim.write_armatures(skelfile_write, animfile_write, scene, self.options['GLOBAL_MATRIX'], self.armatures)
+                        export_objex_anim.write_armatures(skelfile_write, animfile_write, scene, self.options['GLOBAL_MATRIX'], self.armatures, link_anim_basepath)
                     finally:
                         if skelfile:
                             skelfile.close()
@@ -728,6 +735,7 @@ def save(context,
          use_materials=None,
          use_skeletons=None,
          use_animations=None,
+         link_anim_bin=None,
          use_weights=None,
          use_unique_weights=None,
          use_mesh_modifiers=None,
@@ -756,6 +764,7 @@ def save(context,
         'EXPORT_MTL':use_materials,
         'EXPORT_SKEL':use_skeletons,
         'EXPORT_ANIM':use_animations,
+        'EXPORT_LINK_ANIM_BIN':link_anim_bin,
         'EXPORT_WEIGHTS':use_weights,
         'UNIQUE_WEIGHTS':use_unique_weights,
         'APPLY_MODIFIERS':use_mesh_modifiers,


### PR DESCRIPTION
Added an option to save animation data in the Link animation binary format when exporting an animation.

Features:
- Saves .bin files like `x_nameofanim_framecount.bin` where `x.objex` is the main saved file.
- The contents of the bin file are the binary data for the animation itself, no header. (I.e. 0x86 bytes per frame, 3 shorts for root pos, then 3 shorts each for 21 limb rotations, than one short for eyes/mouth). The only required piece of metadata, the number of frames (which is also calculable from the file size), is written into the filename.
- Adjustable scale factor for just the animation positions, x1000 works with the Link IK rig.
- Will not save the bin files if the current skeleton does not have 21 bones (i.e. not Link).

Tested in 2.91 but does not use any special features of any Blender version (besides stuff which was already there in the plugin).